### PR TITLE
Update privacy policy to disclose GTM and GA4 usage

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -225,6 +225,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li>Your store URL (optional)</li>
       <li>Your IP address (collected automatically by Cloudflare Turnstile for spam prevention)</li>
     </ul>
+    <p>When you visit this website, we also automatically collect analytics data through Google Analytics 4 (via Google Tag Manager), including:</p>
+    <ul>
+      <li>Pages visited and time spent on page</li>
+      <li>Approximate geographic location (country/city level, derived from IP address)</li>
+      <li>Browser type, operating system, and device type</li>
+      <li>Referring website or source</li>
+      <li>Anonymized client ID (randomly assigned, not linked to your identity)</li>
+    </ul>
 
     <h2>2. Why we collect it</h2>
     <p>We collect this data solely to:</p>
@@ -232,12 +240,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li>Add you to the early access waitlist</li>
       <li>Contact you about DevsMachina product updates and launch</li>
       <li>Prevent spam and abuse through Cloudflare Turnstile</li>
+      <li>Understand how visitors use the site and improve it (analytics)</li>
     </ul>
     <p>We do not use your data for advertising, profiling, or any purpose beyond the above.</p>
 
     <h2>3. How we store and process your data</h2>
     <p>Form submissions are processed and stored by <strong>Formspree</strong> (formspree.io), a third-party form service. Formspree stores your submission data on their servers. You can review Formspree's privacy policy at <a href="https://formspree.io/legal/privacy-policy" target="_blank" rel="noopener">formspree.io/legal/privacy-policy</a>.</p>
     <p>Spam prevention is handled by <strong>Cloudflare Turnstile</strong>. Cloudflare may process your IP address and browser signals to determine whether a form submission is human. You can review Cloudflare's privacy policy at <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">cloudflare.com/privacypolicy</a>.</p>
+    <p>This website uses <strong>Google Tag Manager</strong> (GTM-KK6K5V4X) to manage and deploy tracking scripts, and <strong>Google Analytics 4</strong> (GA4, measurement ID G-710H8EVH08) to collect anonymized website analytics. Data is processed by Google and may be transferred to and stored on Google's servers. IP anonymization is enabled by default in GA4. You can opt out of Google Analytics tracking using the <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener">Google Analytics Opt-out Browser Add-on</a>.</p>
     <p>This website is hosted on <strong>Cloudflare Pages</strong> and fonts are loaded from <strong>Google Fonts</strong>. Google may log your IP address when fonts are requested. You can review Google's privacy policy at <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">policies.google.com/privacy</a>.</p>
 
     <h2>4. How long we keep your data</h2>
@@ -254,7 +264,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <p>To exercise any of these rights, contact us at <a href="mailto:privacy@devsmachina.app">privacy@devsmachina.app</a>.</p>
 
     <h2>6. Cookies</h2>
-    <p>This website does not use tracking or analytics cookies. Cloudflare Turnstile may set a functional cookie necessary for spam prevention. Google Fonts may set a cookie when fonts are loaded. These are technical necessities and do not track your browsing behavior across other sites.</p>
+    <p>This website uses the following cookies:</p>
+    <ul>
+      <li><strong>Google Analytics 4</strong> — sets cookies (e.g. <code>_ga</code>, <code>_ga_*</code>) to distinguish visitors and track sessions anonymously. These persist for up to 2 years.</li>
+      <li><strong>Cloudflare Turnstile</strong> — may set a functional cookie necessary for spam prevention on form submissions.</li>
+      <li><strong>Google Fonts</strong> — may set a cookie when fonts are loaded from Google's servers.</li>
+      <li><strong>Cookie consent</strong> — we store your cookie banner choice in <code>localStorage</code> so the banner does not reappear.</li>
+    </ul>
+    <p>You can block or delete cookies through your browser settings. Note that disabling cookies may affect some site functionality.</p>
 
     <h2>7. Changes to this policy</h2>
     <p>We may update this policy as the product evolves. Any significant changes will be reflected with an updated date at the top of this page.</p>


### PR DESCRIPTION
- Section 1: add analytics data collected (pages, geo, browser, client ID)
- Section 2: add analytics as a stated purpose
- Section 3: add GTM (GTM-KK6K5V4X) and GA4 (G-710H8EVH08) with opt-out link
- Section 6: replace "no tracking cookies" with accurate cookie list (_ga, _ga_*)

https://claude.ai/code/session_01HVQtNXXCcqkYiMPbxYLMdn