### PR TITLE
Fix insufficient color contrast on cookie decline button

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,7 +867,7 @@
       font-family: var(--mono);
       font-size: 0.78rem;
       font-weight: 400;
-      color: var(--ink-3);
+      color: var(--ink-2);
       background: none;
       border: none;
       cursor: pointer;


### PR DESCRIPTION
Changed .cookie-decline text color from --ink-3 (#6e6e8a) to --ink-2 (#1e1d38) to meet WCAG AA contrast requirements. The previous color yielded ~4.04:1 contrast ratio against the --paper background (#f0eee8), below the 4.5:1 minimum. The updated color gives ~13.3:1 contrast ratio.

Fixes #24

https://claude.ai/code/session_018dWQ1EqbSstCVLdy76GVaW