### PR TITLE
fix: remove display:none on turnstile container to resolve error 600010

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,9 +261,7 @@
       border-color: var(--amber-light);
       box-shadow: 0 4px 20px rgba(239,159,39,0.35);
     }
-    #waitlist-turnstile {
-      display: none;
-    }
+
     .hero-note {
       margin-top: 1rem;
       font-size: 0.82rem;


### PR DESCRIPTION
Turnstile error 600010 fires when the widget container is hidden via CSS. In execute mode, Turnstile must be able to render into a visible element and manages its own invisibility — the container should not be display:none.

https://claude.ai/code/session_01PtgXwwHyDX65xxDXJVKXmF