### PR TITLE
fix: adapt Turnstile integration for Managed mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,6 +753,12 @@
       background-color: rgba(18,17,42,0.4);
     }
     .waitlist-form select option[value=""] { color: rgba(240,238,232,0.65); }
+    #waitlist-turnstile {
+      margin: 0.25rem 0;
+    }
+    #waitlist-turnstile iframe {
+      border-radius: var(--radius);
+    }
     .waitlist-form button {
       font-family: var(--mono);
       font-size: 0.85rem;
@@ -1219,7 +1225,7 @@
 
     const TURNSTILE_SITEKEY = '0x4AAAAAACsW-ibG9m4hyKvk';
     const turnstileIds = {};
-    const pendingSubmit = {};
+
     const storedToken = {};
 
     async function submitForm(formId, successId, token) {
@@ -1253,17 +1259,13 @@
       ['waitlist-form'].forEach(function(formId) {
         const successId = 'waitlist-success';
         const containerId = '#waitlist-turnstile';
-        pendingSubmit[formId] = false;
         turnstileIds[formId] = turnstile.render(containerId, {
           sitekey: TURNSTILE_SITEKEY,
-          appearance: 'execute',
-          'response-timeout': 60000,
           callback: function(token) {
             storedToken[formId] = token;
-            if (pendingSubmit[formId]) {
-              pendingSubmit[formId] = false;
-              submitForm(formId, successId, token);
-            }
+          },
+          'expired-callback': function() {
+            storedToken[formId] = null;
           }
         });
         const form = document.getElementById(formId);
@@ -1278,8 +1280,8 @@
             storedToken[formId] = null;
             submitForm(formId, successId, token);
           } else {
-            pendingSubmit[formId] = true;
-            turnstile.execute(turnstileIds[formId]);
+            btn.textContent = 'Request Early Access';
+            btn.disabled = false;
           }
         });
       });


### PR DESCRIPTION
CF dashboard changed from Execute to Managed mode. In Managed mode the widget renders a visible checkbox — appearance:'execute' and turnstile.execute() are incompatible and cause error 600010.

- Remove appearance:'execute' so widget renders visibly (default 'always')
- Remove turnstile.execute() call from submit handler
- Add expired-callback to clear stale token
- Remove pendingSubmit logic (execute-mode only pattern)
- Add CSS for #waitlist-turnstile container and iframe border-radius

https://claude.ai/code/session_01PtgXwwHyDX65xxDXJVKXmF