### PR TITLE
Add font-display: swap to @font-face fallback definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
       ascent-override: 92%;
       descent-override: 23%;
       line-gap-override: 0%;
+      font-display: swap;
     }
 
     html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }

--- a/privacy.html
+++ b/privacy.html
@@ -39,6 +39,7 @@
       ascent-override: 92%;
       descent-override: 23%;
       line-gap-override: 0%;
+      font-display: swap;
     }
 
     html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }


### PR DESCRIPTION
Adds font-display: swap; to the 'Outfit Fallback' @font-face declarations in index.html and privacy.html to reduce layout thrashing caused by font loading. This instructs the browser to immediately render text with the fallback font while the custom Outfit font loads in the background.

Fixes #37