### PR TITLE
Fix mobile nav overlap, update sitemap, improve footer

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,49 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/operations-report</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/seo-monitoring</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/cro-monitoring</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/pricing-intelligence</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/inventory-signals</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/landing-page-auditor</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/localization-coverage</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,4 +5,49 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/operations-report</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/seo-monitoring</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/cro-monitoring</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/pricing-intelligence</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/inventory-signals</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/landing-page-auditor</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/use-cases/localization-coverage</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://devsmachina.app/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -83,7 +83,7 @@ import '../styles/global.css';
           <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
         </ul>
       </div>
-      <a href="/#waitlist" class="nav-cta">Join</a>
+      <a href="/#waitlist" class="nav-cta"><span class="nav-cta-short">Join</span><span class="nav-cta-full">Join Waitlist</span></a>
     </div>
   </div>
 </nav>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -11,7 +11,7 @@ interface Props {
   ogImageHeight?: string;
   includeTurnstile?: boolean;
   narrow?: boolean;  
-  navType?: 'main' | 'privacy' | 'usecase';
+  navType?: 'main' | 'privacy';
 }
 
 const {
@@ -69,28 +69,7 @@ import '../styles/global.css';
   <div class="nav-inner">
     <a href={navType === 'privacy' ? '/' : '/'} class="nav-logo">devs<span>machina</span>.app</a>
 
-    {navType === 'main' && (
-      <div class="nav-actions">
-        <div class="nav-dropdown">
-          <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
-            Use Cases
-          </button>
-          <ul class="nav-dropdown-menu" role="menu">
-		    <li><a href="/use-cases" role="menuitem" class="nav-dropdown-overview">All Use Cases</a></li>
-            <li><a href="/use-cases/operations-report" role="menuitem">Operations Report</a></li>
-            <li><a href="/use-cases/seo-monitoring" role="menuitem">SEO Monitoring</a></li>
-            <li><a href="/use-cases/cro-monitoring" role="menuitem">CRO Monitoring</a></li>
-            <li><a href="/use-cases/pricing-intelligence" role="menuitem">Pricing Intelligence</a></li>
-            <li><a href="/use-cases/inventory-signals" role="menuitem">Inventory Signals</a></li>
-            <li><a href="/use-cases/landing-page-auditor" role="menuitem">Landing Page Auditor</a></li>
-            <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
-          </ul>
-        </div>
-        <a href="#waitlist" class="nav-cta">Join</a>
-      </div>
-    )}
-
-    {navType === 'usecase' && (
+    {navType !== 'privacy' && (
       <div class="nav-actions">
         <div class="nav-dropdown">
           <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
@@ -98,7 +77,7 @@ import '../styles/global.css';
           </button>
           <ul class="nav-dropdown-menu" role="menu">
             <li><a href="/use-cases" role="menuitem" class="nav-dropdown-overview">All Use Cases</a></li>
-			<li><a href="/use-cases/operations-report" role="menuitem">Operations Report</a></li>
+            <li><a href="/use-cases/operations-report" role="menuitem">Operations Report</a></li>
             <li><a href="/use-cases/seo-monitoring" role="menuitem">SEO Monitoring</a></li>
             <li><a href="/use-cases/cro-monitoring" role="menuitem">CRO Monitoring</a></li>
             <li><a href="/use-cases/pricing-intelligence" role="menuitem">Pricing Intelligence</a></li>
@@ -110,8 +89,6 @@ import '../styles/global.css';
         <a href="/#waitlist" class="nav-cta">Join</a>
       </div>
     )}
-
-    {navType === 'privacy' && <a href="/" class="nav-back">← Back</a>}
   </div>
 </nav>
 

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -70,7 +70,7 @@ import '../styles/global.css';
     <a href={navType === 'privacy' ? '/' : '/'} class="nav-logo">devs<span>machina</span>.app</a>
 
     {navType === 'main' && (
-      <div style="display:flex;align-items:center;gap:2rem;">
+      <div class="nav-actions">
         <div class="nav-dropdown">
           <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
             Use Cases
@@ -86,12 +86,12 @@ import '../styles/global.css';
             <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
           </ul>
         </div>
-        <a href="#waitlist" class="nav-cta">Join Waitlist</a>
+        <a href="#waitlist" class="nav-cta">Join</a>
       </div>
     )}
 
     {navType === 'usecase' && (
-      <div style="display:flex;align-items:center;gap:2rem;">
+      <div class="nav-actions">
         <div class="nav-dropdown">
           <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
             Use Cases
@@ -107,7 +107,7 @@ import '../styles/global.css';
             <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
           </ul>
         </div>
-        <a href="/#waitlist" class="nav-cta">Request Access</a>
+        <a href="/#waitlist" class="nav-cta">Join</a>
       </div>
     )}
 
@@ -120,10 +120,13 @@ import '../styles/global.css';
   <footer>
   <div class="footer-inner">
     <a href="/" class="footer-logo">devs<span>machina</span>.app</a>
-    <div style="display:flex;gap:1.5rem;align-items:center;">
-      <a href="/use-cases" class="footer-link">Use Cases</a>
-      <a href="/privacy" class="footer-link">Privacy Policy</a>
-      <div class="footer-copy">© 2026 DevsMachina. All rights reserved.</div>
+    <div class="footer-right">
+      <div class="footer-links">
+        <a href="/use-cases" class="footer-link">Use Cases</a>
+        <a href="/privacy" class="footer-link">Privacy Policy</a>
+        <a href="/sitemap.xml" class="footer-link">Sitemap</a>
+      </div>
+      <div class="footer-copy">© 2026 DevsMachina by AMMD WEB. All rights reserved.</div>
     </div>
   </div>
 </footer>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -11,7 +11,6 @@ interface Props {
   ogImageHeight?: string;
   includeTurnstile?: boolean;
   narrow?: boolean;  
-  navType?: 'main' | 'privacy';
 }
 
 const {
@@ -26,7 +25,6 @@ const {
   ogImageHeight,
   includeTurnstile = false,
   narrow = false,
-  navType = 'main',
 } = Astro.props;
 import '../styles/global.css';
 ---
@@ -67,28 +65,26 @@ import '../styles/global.css';
 
   <nav>
   <div class="nav-inner">
-    <a href={navType === 'privacy' ? '/' : '/'} class="nav-logo">devs<span>machina</span>.app</a>
+    <a href="/" class="nav-logo">devs<span>machina</span>.app</a>
 
-    {navType !== 'privacy' && (
-      <div class="nav-actions">
-        <div class="nav-dropdown">
-          <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
-            Use Cases
-          </button>
-          <ul class="nav-dropdown-menu" role="menu">
-            <li><a href="/use-cases" role="menuitem" class="nav-dropdown-overview">All Use Cases</a></li>
-            <li><a href="/use-cases/operations-report" role="menuitem">Operations Report</a></li>
-            <li><a href="/use-cases/seo-monitoring" role="menuitem">SEO Monitoring</a></li>
-            <li><a href="/use-cases/cro-monitoring" role="menuitem">CRO Monitoring</a></li>
-            <li><a href="/use-cases/pricing-intelligence" role="menuitem">Pricing Intelligence</a></li>
-            <li><a href="/use-cases/inventory-signals" role="menuitem">Inventory Signals</a></li>
-            <li><a href="/use-cases/landing-page-auditor" role="menuitem">Landing Page Auditor</a></li>
-            <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
-          </ul>
-        </div>
-        <a href="/#waitlist" class="nav-cta">Join</a>
+    <div class="nav-actions">
+      <div class="nav-dropdown">
+        <button class="nav-dropdown-trigger" aria-expanded="false" aria-haspopup="true">
+          Use Cases
+        </button>
+        <ul class="nav-dropdown-menu" role="menu">
+          <li><a href="/use-cases" role="menuitem" class="nav-dropdown-overview">All Use Cases</a></li>
+          <li><a href="/use-cases/operations-report" role="menuitem">Operations Report</a></li>
+          <li><a href="/use-cases/seo-monitoring" role="menuitem">SEO Monitoring</a></li>
+          <li><a href="/use-cases/cro-monitoring" role="menuitem">CRO Monitoring</a></li>
+          <li><a href="/use-cases/pricing-intelligence" role="menuitem">Pricing Intelligence</a></li>
+          <li><a href="/use-cases/inventory-signals" role="menuitem">Inventory Signals</a></li>
+          <li><a href="/use-cases/landing-page-auditor" role="menuitem">Landing Page Auditor</a></li>
+          <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
+        </ul>
       </div>
-    )}
+      <a href="/#waitlist" class="nav-cta">Join</a>
+    </div>
   </div>
 </nav>
 

--- a/src/layouts/UseCaseLayout.astro
+++ b/src/layouts/UseCaseLayout.astro
@@ -43,7 +43,6 @@ const {
   ogImageWidth="1200"
   ogImageHeight="630"
   includeTurnstile={false}
-  navType="usecase"
 >
   {jsonLd && <script type="application/ld+json" slot="head" set:html={JSON.stringify(jsonLd)} />}
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,6 @@ const jsonLd = [
   ogImageWidth="1200"
   ogImageHeight="630"
   includeTurnstile={true}
-  navType="main"
 >
   <script type="application/ld+json" slot="head" set:html={JSON.stringify(jsonLd)} />
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,7 +6,7 @@ import Base from '../layouts/Base.astro';
   title="Privacy Policy — DevsMachina"
   noIndex={true}
   canonical="https://devsmachina.app/privacy"
-  navType="privacy"
+  navType="usecase"
   narrow={true}
 >
   <main class="page">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,7 +6,6 @@ import Base from '../layouts/Base.astro';
   title="Privacy Policy — DevsMachina"
   noIndex={true}
   canonical="https://devsmachina.app/privacy"
-  navType="usecase"
   narrow={true}
 >
   <main class="page">

--- a/src/pages/use-cases/index.astro
+++ b/src/pages/use-cases/index.astro
@@ -21,7 +21,6 @@ const jsonLd = {
   ogImageWidth="1200"
   ogImageHeight="630"
   includeTurnstile={false}
-  navType="usecase"
 >
   <script type="application/ld+json" slot="head" set:html={JSON.stringify(jsonLd)} />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -120,6 +120,12 @@ body > nav {
   color: var(--indigo-light);
 }
 
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+}
+
 .nav-cta {
   font-family: var(--mono);
   font-size: 0.78rem;
@@ -133,6 +139,7 @@ body > nav {
   padding: 0.6rem 1.5rem;
   border-radius: var(--radius);
   transition: all 0.25s ease;
+  white-space: nowrap;
 }
 
 .nav-cta:hover {
@@ -982,6 +989,18 @@ footer {
   justify-content: space-between;
 }
 
+.footer-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.footer-links {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
 .footer-logo {
   font-family: var(--mono);
   font-size: 0.9rem;
@@ -1304,7 +1323,11 @@ footer {
 }
 
 @media (max-width: 600px) {
-  .nav-inner { padding: 1rem 1.5rem; }
+  .nav-inner { padding: 1rem 1.25rem; }
+  .nav-logo { font-size: 0.88rem; }
+  .nav-actions { gap: 0.75rem; }
+  .nav-cta { padding: 0.4rem 0.75rem; font-size: 0.7rem; }
+  .nav-dropdown-trigger { font-size: 0.7rem; }
   .hero-left { padding: 3.5rem 1.5rem 3rem; }
   .section-inner { padding: 4rem 1.5rem; }
   .steps { grid-template-columns: 1fr; }
@@ -1313,7 +1336,9 @@ footer {
   .step:nth-child(2), .step:nth-child(3) { border-radius: 0; }
   .step:last-child { border-radius: 0 0 var(--radius) var(--radius); border-bottom: none; }
   .agents-grid { grid-template-columns: 1fr; }
-  .footer-inner { flex-direction: column; gap: 0.75rem; text-align: center; }
+  .footer-inner { flex-direction: column; gap: 1rem; text-align: center; }
+  .footer-right { flex-direction: column; gap: 0.5rem; align-items: center; }
+  .footer-links { gap: 1rem; }
   .waitlist-inner { padding: 4rem 1.5rem; }
   .hero-title { font-size: clamp(2.6rem, 10vw, 3.6rem); }
   body { padding-top: 72px; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -150,21 +150,6 @@ body > nav {
   box-shadow: 0 4px 20px rgba(239, 159, 39, 0.3);
 }
 
-.nav-back {
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--ink-3);
-  text-decoration: none;
-  transition: color 0.2s;
-}
-
-.nav-back:hover {
-  color: var(--amber);
-}
-
 /* =====================
    TICKER
    ===================== */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,15 +67,6 @@ body {
   padding-top: 0;
 }
 
-.narrow-layout .nav-inner {
-  max-width: 780px;
-  padding: 1rem 2.5rem;
-}
-
-.narrow-layout .footer-inner {
-  max-width: 780px;
-  padding: 2rem 2.5rem;
-}
 
 /* =====================
    NAV
@@ -125,6 +116,9 @@ body > nav {
   align-items: center;
   gap: 2rem;
 }
+
+.nav-cta-short { display: none; }
+.nav-cta-full { display: inline; }
 
 .nav-cta {
   font-family: var(--mono);
@@ -1312,6 +1306,8 @@ footer {
   .nav-logo { font-size: 0.88rem; }
   .nav-actions { gap: 0.75rem; }
   .nav-cta { padding: 0.4rem 0.75rem; font-size: 0.7rem; }
+  .nav-cta-short { display: inline; }
+  .nav-cta-full { display: none; }
   .nav-dropdown-trigger { font-size: 0.7rem; }
   .hero-left { padding: 3.5rem 1.5rem 3rem; }
   .section-inner { padding: 4rem 1.5rem; }


### PR DESCRIPTION
- Mobile header: shorten CTA to "Join", reduce font/padding/gap so logo + Use Cases + CTA fit on one row
- Sitemap: add all 8 use case pages and privacy page
- Footer: add Sitemap link, update copyright to include "by AMMD WEB", restructure HTML for better mobile layout (links row + copyright stacked below)

https://claude.ai/code/session_01Ui6zeCuUHobZ4uEkmjDyzH