### PR TITLE
Fix privacy footer width; responsive CTA label

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -83,7 +83,7 @@ import '../styles/global.css';
           <li><a href="/use-cases/localization-coverage" role="menuitem">Localization Coverage</a></li>
         </ul>
       </div>
-      <a href="/#waitlist" class="nav-cta">Join</a>
+      <a href="/#waitlist" class="nav-cta"><span class="nav-cta-short">Join</span><span class="nav-cta-full">Join Waitlist</span></a>
     </div>
   </div>
 </nav>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,15 +67,6 @@ body {
   padding-top: 0;
 }
 
-.narrow-layout .nav-inner {
-  max-width: 780px;
-  padding: 1rem 2.5rem;
-}
-
-.narrow-layout .footer-inner {
-  max-width: 780px;
-  padding: 2rem 2.5rem;
-}
 
 /* =====================
    NAV
@@ -125,6 +116,9 @@ body > nav {
   align-items: center;
   gap: 2rem;
 }
+
+.nav-cta-short { display: none; }
+.nav-cta-full { display: inline; }
 
 .nav-cta {
   font-family: var(--mono);
@@ -1312,6 +1306,8 @@ footer {
   .nav-logo { font-size: 0.88rem; }
   .nav-actions { gap: 0.75rem; }
   .nav-cta { padding: 0.4rem 0.75rem; font-size: 0.7rem; }
+  .nav-cta-short { display: inline; }
+  .nav-cta-full { display: none; }
   .nav-dropdown-trigger { font-size: 0.7rem; }
   .hero-left { padding: 3.5rem 1.5rem 3rem; }
   .section-inner { padding: 4rem 1.5rem; }


### PR DESCRIPTION
- Remove .narrow-layout overrides for nav/footer so header and footer always render at full 1200px width regardless of page content width
- CTA shows "Join Waitlist" on desktop, "Join" on mobile (≤600px)

https://claude.ai/code/session_01Ui6zeCuUHobZ4uEkmjDyzH