### PR TITLE
Refactor GA4 initialization and consent handling

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -57,7 +57,11 @@ import '../styles/global.css';
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" /></noscript>
   {includeTurnstile && <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onTurnstileLoad" defer></script>}
   <script is:inline>
-    window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag("consent","default",{analytics_storage:"denied",ad_storage:"denied",ad_user_data:"denied",ad_personalization:"denied"});function initGA4(){if(window.ga4Initialized)return;const e=document.createElement("script");e.async=!0;e.src="https://www.googletagmanager.com/gtag/js?id=G-710H8EVH08";document.head.appendChild(e);gtag("js",new Date);gtag("config","G-710H8EVH08",{anonymize_ip:!0});window.ga4Initialized=!0}if(localStorage.getItem("cookie_consent")==="accepted"){"complete"===document.readyState?setTimeout(initGA4,2000):window.addEventListener("load",()=>setTimeout(initGA4,2000));}
+    window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}
+    gtag("consent","default",{analytics_storage:"denied",ad_storage:"denied",ad_user_data:"denied",ad_personalization:"denied",wait_for_update:500});
+    const _gas=document.createElement("script");_gas.async=true;_gas.src="https://www.googletagmanager.com/gtag/js?id=G-710H8EVH08";document.head.appendChild(_gas);
+    gtag("js",new Date());gtag("config","G-710H8EVH08");
+    if(localStorage.getItem("cookie_consent")==="accepted"){gtag("consent","update",{analytics_storage:"granted",ad_user_data:"granted",ad_personalization:"granted",ad_storage:"granted"});}
   </script>
   <slot name="head" />
 </head>
@@ -124,7 +128,6 @@ import '../styles/global.css';
       localStorage.setItem('cookie_consent', 'accepted');
       document.getElementById('cookie-banner').classList.remove('visible');
       gtag("consent","update",{analytics_storage:"granted",ad_user_data:"granted",ad_personalization:"granted",ad_storage:"granted"});
-      initGA4();
     }
     function declineCookies() {
       localStorage.setItem('cookie_consent', 'declined');


### PR DESCRIPTION
## Summary
Refactored Google Analytics 4 (GA4) initialization to load the tracking script immediately on page load rather than deferring it until cookie consent is accepted. The consent state is now managed through the Consent Mode API, with analytics storage toggled based on user preferences.

## Key Changes
- **Immediate GA4 script loading**: The GA4 tracking script now loads on every page load, with consent mode set to "denied" by default
- **Consent Mode API integration**: Added `wait_for_update: 500` parameter to the initial consent declaration to allow time for consent updates
- **Dynamic consent updates**: When users accept cookies, a consent "update" call grants analytics and personalization permissions instead of initializing GA4 separately
- **Removed deferred initialization**: Eliminated the `initGA4()` function call from the cookie acceptance handler, as GA4 is now always loaded with appropriate consent settings
- **Improved code formatting**: Reformatted the inline script for better readability while maintaining functionality

## Implementation Details
- GA4 now respects the Consent Mode API, allowing Google to handle data collection based on the current consent state
- The `wait_for_update` parameter gives the page 500ms to update consent before GA4 starts processing data
- Cookie acceptance now triggers a consent update rather than a full script initialization, reducing redundant operations
- The tracking script is loaded asynchronously to avoid blocking page rendering

https://claude.ai/code/session_019vy6Td6Fzv7zprfYnZqyxa